### PR TITLE
RIA-5722 Allow calls to endpoint /service-request-update

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -48,7 +48,7 @@ idam:
     microservice: ${IA_S2S_MICROSERVICE:ia}
     url: ${S2S_URL:http://127.0.0.1:4502}
   s2s-authorised:
-    services: ${IA_S2S_AUTHORIZED_SERVICES:iac,payment_app}
+    services: ${IA_S2S_AUTHORIZED_SERVICES:iac}
 
 fees-register:
   api:
@@ -100,6 +100,7 @@ security:
     - "/csrf"
     - "/testing-support/**"
     - "/payment-updates"
+    - "/service-request-update"
   roleEventAccess:
     citizen:
     - "startAppeal"


### PR DESCRIPTION
### JIRA link (if applicable) ###
[RIA-5722](https://tools.hmcts.net/jira/browse/RIA-5722)


### Change description ###
- Allow calls to /service-request-update (same approach as for the endpoint hit by the old way of paying /payment-updates)


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
