### PR TITLE
Ria 6109 create service request when submitting case

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/iacasepaymentsapi/domain/handlers/presubmit/PaymentAppealPreparer.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasepaymentsapi/domain/handlers/presubmit/PaymentAppealPreparer.java
@@ -82,7 +82,7 @@ public class PaymentAppealPreparer implements PreSubmitCallbackHandler<AsylumCas
                                 Callback<AsylumCase> callback,
                                 boolean isLegalRepJourney) {
         return callbackStage == PreSubmitCallbackStage.ABOUT_TO_SUBMIT
-               && callback.getEvent() == Event.START_APPEAL
+               && callback.getEvent() == Event.SUBMIT_APPEAL
                && isLegalRepJourney
                && isHuOrEaOrPa(callback.getCaseDetails().getCaseData());
     }

--- a/src/main/java/uk/gov/hmcts/reform/iacasepaymentsapi/infrastructure/service/ServiceRequestService.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasepaymentsapi/infrastructure/service/ServiceRequestService.java
@@ -42,7 +42,9 @@ public class ServiceRequestService {
 
         CaseDetails<AsylumCase> caseDetails = callback.getCaseDetails();
         AsylumCase asylumCase = caseDetails.getCaseData();
-        String appealReferenceNumber = String.valueOf(caseDetails.getId());
+        String ccdCaseReferenceNumber = String.valueOf(caseDetails.getId());
+        String appealReferenceNumber = asylumCase.read(AsylumCaseDefinition.APPEAL_REFERENCE_NUMBER, String.class)
+            .orElse("");
         String appellantGivenNames = asylumCase.read(AsylumCaseDefinition.APPELLANT_GIVEN_NAMES, String.class)
             .orElse("");
         String appellantFamilyName = asylumCase.read(AsylumCaseDefinition.APPELLANT_FAMILY_NAME, String.class)
@@ -63,7 +65,7 @@ public class ServiceRequestService {
                         .responsibleParty(responsibleParty)
                         .build())
                 .caseReference(appealReferenceNumber)
-                .ccdCaseNumber(appealReferenceNumber)
+                .ccdCaseNumber(ccdCaseReferenceNumber)
                 .fees(new FeeDto[]{
                     FeeDto.builder()
                         .calculatedAmount(fee.getCalculatedAmount())

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -76,7 +76,7 @@ rd-professional:
 payment:
   api:
     url: ${PAYMENT_API_URL:http://localhost:8083}
-    callback-url: ${PAY_CALLBACK_URL:http://localhost:8096}
+    callback-url: ${PAY_CALLBACK_URL:http://localhost:8096/service-request-update}
   params:
     organisationUrn: immigration and asylum chamber
     siteId: BFA1
@@ -108,6 +108,7 @@ security:
     - "paymentAppeal"
     caseworker-ia-legalrep-solicitor:
     - "startAppeal"
+    - "submitAppeal"
     - "editAppeal"
     - "paymentAppeal"
     - "payAndSubmitAppeal"

--- a/src/test/java/uk/gov/hmcts/reform/iacasepaymentsapi/domain/handlers/presubmit/PaymentAppealPreparerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacasepaymentsapi/domain/handlers/presubmit/PaymentAppealPreparerTest.java
@@ -432,7 +432,7 @@ class PaymentAppealPreparerTest {
 
     @Test
     void should_send_request_for_service_request_if_is_ways_to_pay() throws Exception {
-        when(callback.getEvent()).thenReturn(Event.START_APPEAL);
+        when(callback.getEvent()).thenReturn(Event.SUBMIT_APPEAL);
         when(refDataService.getOrganisationResponse())
             .thenReturn(organisationResponse);
 
@@ -462,7 +462,7 @@ class PaymentAppealPreparerTest {
                                 Callback<AsylumCase> callback,
                                 boolean isLegalRepJourney) {
         return callbackStage == PreSubmitCallbackStage.ABOUT_TO_SUBMIT
-               && callback.getEvent() == Event.START_APPEAL
+               && callback.getEvent() == Event.SUBMIT_APPEAL
                && isLegalRepJourney;
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/iacasepaymentsapi/infrastructure/service/ServiceRequestServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacasepaymentsapi/infrastructure/service/ServiceRequestServiceTest.java
@@ -39,6 +39,7 @@ public class ServiceRequestServiceTest {
     private static final String APPELLANT_GIVEN_NAMES = "Name";
     private static final String APPELLANT_FAMILY_NAMES = "Surname";
     private static final String CALLBACK_URL = "some-callback-url";
+    private static final String APPEAL_REFERENCE_NUMBER = "EA/00001/01";
     private static final long CASE_ID = 1111222233334444L;
 
     @Mock SystemTokenGenerator systemTokenGenerator;
@@ -93,6 +94,8 @@ public class ServiceRequestServiceTest {
         when(caseDetails.getCaseData()).thenReturn(asylumCase);
         when(asylumCase.read(AsylumCaseDefinition.APPELLANT_GIVEN_NAMES, String.class))
             .thenReturn(Optional.of(APPELLANT_GIVEN_NAMES));
+        when(asylumCase.read(AsylumCaseDefinition.APPEAL_REFERENCE_NUMBER, String.class))
+            .thenReturn(Optional.of(APPEAL_REFERENCE_NUMBER));
         when(asylumCase.read(AsylumCaseDefinition.APPELLANT_FAMILY_NAME, String.class))
             .thenReturn(Optional.of(APPELLANT_FAMILY_NAMES));
         when(caseDetails.getId()).thenReturn(CASE_ID);
@@ -113,7 +116,7 @@ public class ServiceRequestServiceTest {
         assertEquals("some-callback-url", actual.getCallBackUrl());
         assertEquals("payment", actual.getCasePaymentRequest().getAction());
         assertEquals("Name Surname", actual.getCasePaymentRequest().getResponsibleParty());
-        assertEquals("1111222233334444", actual.getCaseReference());
+        assertEquals("EA/00001/01", actual.getCaseReference());
         assertEquals("1111222233334444", actual.getCcdCaseNumber());
         assertEquals("some-version", actual.getFees()[0].getVersion());
         assertEquals("some-code", actual.getFees()[0].getCode());


### PR DESCRIPTION
### JIRA link (if applicable) ###
[RIA-6109](https://tools.hmcts.net/jira/browse/RIA-6109)


### Change description ###
- PaymentAppealPreparer changed to make new WaysToPay payment handled with SUBMIT_APPEAL rather than START_APPEAL
- ServiceRequestService changed so that it sends a ServiceRequestRequest that contains both ccdCaseNumber (1111222233334444) and case reference (EA/50000/2022)
- callback-url default value updated for consistency (has no impacts on different environments)


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
