### PR TITLE
RIA-6070 Retain old events inflight cases

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/iacasepaymentsapi/domain/entities/AsylumCaseDefinition.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasepaymentsapi/domain/entities/AsylumCaseDefinition.java
@@ -73,7 +73,10 @@ public enum AsylumCaseDefinition {
     JOURNEY_TYPE(
         "journeyType", new TypeReference<JourneyType>(){}),
     REMISSION_TYPE(
-        "remissionType", new TypeReference<RemissionType>(){});
+        "remissionType", new TypeReference<RemissionType>(){}),
+    HAS_SERVICE_REQUEST_ALREADY(
+        "hasServiceRequestAlready", new TypeReference<YesOrNo>(){}),
+    ;
 
     private final String value;
     private final TypeReference typeReference;

--- a/src/main/java/uk/gov/hmcts/reform/iacasepaymentsapi/domain/entities/ccd/Event.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasepaymentsapi/domain/entities/ccd/Event.java
@@ -13,6 +13,7 @@ public enum Event {
     PAY_FOR_APPEAL("payForAppeal"),
     RECORD_REMISSION_DECISION("recordRemissionDecision"),
     UPDATE_PAYMENT_STATUS("updatePaymentStatus"),
+    GENERATE_SERVICE_REQUEST("generateServiceRequest"),
 
     @JsonEnumDefaultValue
     UNKNOWN("unknown");

--- a/src/main/java/uk/gov/hmcts/reform/iacasepaymentsapi/domain/handlers/presubmit/PaymentAppealPreparer.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasepaymentsapi/domain/handlers/presubmit/PaymentAppealPreparer.java
@@ -2,7 +2,14 @@ package uk.gov.hmcts.reform.iacasepaymentsapi.domain.handlers.presubmit;
 
 import static java.util.Objects.isNull;
 import static java.util.Objects.requireNonNull;
-import static uk.gov.hmcts.reform.iacasepaymentsapi.domain.entities.AsylumCaseDefinition.*;
+import static uk.gov.hmcts.reform.iacasepaymentsapi.domain.entities.AsylumCaseDefinition.APPEAL_TYPE;
+import static uk.gov.hmcts.reform.iacasepaymentsapi.domain.entities.AsylumCaseDefinition.HAS_PBA_ACCOUNTS;
+import static uk.gov.hmcts.reform.iacasepaymentsapi.domain.entities.AsylumCaseDefinition.HAS_SERVICE_REQUEST_ALREADY;
+import static uk.gov.hmcts.reform.iacasepaymentsapi.domain.entities.AsylumCaseDefinition.JOURNEY_TYPE;
+import static uk.gov.hmcts.reform.iacasepaymentsapi.domain.entities.AsylumCaseDefinition.PAYMENT_ACCOUNT_LIST;
+import static uk.gov.hmcts.reform.iacasepaymentsapi.domain.entities.AsylumCaseDefinition.PAYMENT_STATUS;
+import static uk.gov.hmcts.reform.iacasepaymentsapi.domain.entities.AsylumCaseDefinition.REMISSION_DECISION;
+import static uk.gov.hmcts.reform.iacasepaymentsapi.domain.entities.AsylumCaseDefinition.REMISSION_TYPE;
 import static uk.gov.hmcts.reform.iacasepaymentsapi.domain.entities.payment.PaymentStatus.PAYMENT_PENDING;
 
 import feign.FeignException;

--- a/src/main/java/uk/gov/hmcts/reform/iacasepaymentsapi/domain/handlers/presubmit/PaymentAppealPreparer.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasepaymentsapi/domain/handlers/presubmit/PaymentAppealPreparer.java
@@ -143,13 +143,16 @@ public class PaymentAppealPreparer implements PreSubmitCallbackHandler<AsylumCas
             return response;
         }
 
-        if (isWaysToPay(callbackStage, callback, isLegalRepJourney(asylumCase))) {
+        YesOrNo hasServiceRequestAlready = asylumCase.read(HAS_SERVICE_REQUEST_ALREADY, YesOrNo.class)
+            .orElse(YesOrNo.NO);
+
+        if (isWaysToPay(callbackStage, callback, isLegalRepJourney(asylumCase))
+            && hasServiceRequestAlready != YesOrNo.YES) {
             try {
                 ServiceRequestResponse serviceRequestResponse = serviceRequestService
                     .createServiceRequest(callback, fee);
                 if (serviceRequestResponse.getServiceRequestReference() != null) {
                     asylumCase.write(HAS_SERVICE_REQUEST_ALREADY, YesOrNo.YES);
-
                 } else {
                     asylumCase.write(HAS_SERVICE_REQUEST_ALREADY, YesOrNo.NO);
                 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -113,6 +113,7 @@ security:
     - "paymentAppeal"
     - "payAndSubmitAppeal"
     - "payForAppeal"
+    - "generateServiceRequest"
     caseworker-ia-admofficer:
     - "recordRemissionDecision"
     caseworker-ia-system:

--- a/src/test/java/uk/gov/hmcts/reform/iacasepaymentsapi/domain/entities/ccd/EventTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacasepaymentsapi/domain/entities/ccd/EventTest.java
@@ -17,12 +17,13 @@ public class EventTest {
         assertEquals("submitAppeal", Event.SUBMIT_APPEAL.toString());
         assertEquals("recordRemissionDecision", Event.RECORD_REMISSION_DECISION.toString());
         assertEquals("updatePaymentStatus", Event.UPDATE_PAYMENT_STATUS.toString());
+        assertEquals("generateServiceRequest", Event.GENERATE_SERVICE_REQUEST.toString());
         assertEquals("unknown", Event.UNKNOWN.toString());
     }
 
     @Test
     public void if_this_test_fails_it_is_because_it_needs_updating_with_your_changes() {
 
-        assertEquals(9, Event.values().length);
+        assertEquals(10, Event.values().length);
     }
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RIA-6070

### Change description ###

- Updated PaymentAppealPreparer to allow for new event 'generateServiceRequest' i.e. Make a payment to generate new service request
- Added new event to Event.java and new fields to AsylumCaseFieldDefinition.java
- Updated unit tests

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
