### PR TITLE
RIA-6161 post submit service request classes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -268,7 +268,8 @@ def versions = [
   springBoot      : '2.6.3',
   springfoxSwagger: '2.9.2',
   pact_version    : '4.1.7',
-  serenity        : '2.2.12'
+  serenity        : '2.2.12',
+  springDoc       : '1.6.8'
 ]
 
 ext.libraries = [
@@ -314,6 +315,8 @@ dependencies {
 
   compile group: 'uk.gov.hmcts.reform', name: 'service-auth-provider-client', version: '3.1.2'
   implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.11.2'
+
+  implementation group:  'org.springdoc', name: 'springdoc-openapi-ui', version: versions.springDoc
 
   implementation group: 'uk.gov.hmcts.reform.auth', name: 'auth-checker-lib', version: '2.1.4'
 

--- a/src/main/java/uk/gov/hmcts/reform/iacasepaymentsapi/domain/entities/ccd/callback/PostSubmitCallbackResponse.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasepaymentsapi/domain/entities/ccd/callback/PostSubmitCallbackResponse.java
@@ -1,0 +1,37 @@
+package uk.gov.hmcts.reform.iacasepaymentsapi.domain.entities.ccd.callback;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import java.util.Optional;
+
+@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+public class PostSubmitCallbackResponse {
+
+    private Optional<String> confirmationHeader = Optional.empty();
+    private Optional<String> confirmationBody = Optional.empty();
+
+    public Optional<String> getConfirmationHeader() {
+        return confirmationHeader;
+    }
+
+    public Optional<String> getConfirmationBody() {
+        return confirmationBody;
+    }
+
+    public void setConfirmationHeader(String confirmationHeader) {
+        this.confirmationHeader = Optional.ofNullable(confirmationHeader);
+    }
+
+    public void setConfirmationBody(String confirmationBody) {
+        this.confirmationBody = Optional.ofNullable(confirmationBody);
+    }
+
+    public PostSubmitCallbackResponse() {
+        // noop -- for deserializer
+    }
+
+    public PostSubmitCallbackResponse(String header, String body) {
+        this.confirmationHeader = Optional.of(header);
+        this.confirmationBody = Optional.of(body);
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/iacasepaymentsapi/domain/entities/ccd/callback/PostSubmitCallbackStage.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasepaymentsapi/domain/entities/ccd/callback/PostSubmitCallbackStage.java
@@ -1,0 +1,17 @@
+package uk.gov.hmcts.reform.iacasepaymentsapi.domain.entities.ccd.callback;
+
+public enum PostSubmitCallbackStage {
+
+    CCD_SUBMITTED("ccdSubmitted");
+
+    private final String id;
+
+    PostSubmitCallbackStage(String id) {
+        this.id = id;
+    }
+
+    @Override
+    public String toString() {
+        return id;
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/iacasepaymentsapi/domain/handlers/PostSubmitCallbackHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasepaymentsapi/domain/handlers/PostSubmitCallbackHandler.java
@@ -1,0 +1,17 @@
+package uk.gov.hmcts.reform.iacasepaymentsapi.domain.handlers;
+
+import uk.gov.hmcts.reform.iacasepaymentsapi.domain.entities.ccd.CaseData;
+import uk.gov.hmcts.reform.iacasepaymentsapi.domain.entities.ccd.callback.Callback;
+import uk.gov.hmcts.reform.iacasepaymentsapi.domain.entities.ccd.callback.PostSubmitCallbackResponse;
+import uk.gov.hmcts.reform.iacasepaymentsapi.domain.entities.ccd.callback.PostSubmitCallbackStage;
+
+public interface PostSubmitCallbackHandler<T extends CaseData> {
+
+    boolean canHandle(
+        PostSubmitCallbackStage callbackStage, Callback<T> callback
+    );
+
+    PostSubmitCallbackResponse handle(
+        PostSubmitCallbackStage callbackStage, Callback<T> callback
+    );
+}

--- a/src/main/java/uk/gov/hmcts/reform/iacasepaymentsapi/domain/handlers/postsubmit/SubmitAppealCreateServiceRequestHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasepaymentsapi/domain/handlers/postsubmit/SubmitAppealCreateServiceRequestHandler.java
@@ -1,0 +1,116 @@
+package uk.gov.hmcts.reform.iacasepaymentsapi.domain.handlers.postsubmit;
+
+import static java.util.Objects.requireNonNull;
+import static uk.gov.hmcts.reform.iacasepaymentsapi.domain.entities.AsylumCaseDefinition.APPEAL_TYPE;
+import static uk.gov.hmcts.reform.iacasepaymentsapi.domain.entities.AsylumCaseDefinition.JOURNEY_TYPE;
+import static uk.gov.hmcts.reform.iacasepaymentsapi.domain.entities.AsylumCaseDefinition.REMISSION_DECISION;
+import static uk.gov.hmcts.reform.iacasepaymentsapi.domain.entities.AsylumCaseDefinition.REMISSION_TYPE;
+
+import java.util.List;
+import java.util.Optional;
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.reform.iacasepaymentsapi.domain.entities.AppealType;
+import uk.gov.hmcts.reform.iacasepaymentsapi.domain.entities.AsylumCase;
+import uk.gov.hmcts.reform.iacasepaymentsapi.domain.entities.JourneyType;
+import uk.gov.hmcts.reform.iacasepaymentsapi.domain.entities.RemissionDecision;
+import uk.gov.hmcts.reform.iacasepaymentsapi.domain.entities.RemissionType;
+import uk.gov.hmcts.reform.iacasepaymentsapi.domain.entities.ccd.Event;
+import uk.gov.hmcts.reform.iacasepaymentsapi.domain.entities.ccd.callback.Callback;
+import uk.gov.hmcts.reform.iacasepaymentsapi.domain.entities.ccd.callback.PostSubmitCallbackResponse;
+import uk.gov.hmcts.reform.iacasepaymentsapi.domain.entities.ccd.callback.PostSubmitCallbackStage;
+import uk.gov.hmcts.reform.iacasepaymentsapi.domain.entities.fee.Fee;
+import uk.gov.hmcts.reform.iacasepaymentsapi.domain.entities.payment.ServiceRequestResponse;
+import uk.gov.hmcts.reform.iacasepaymentsapi.domain.handlers.PostSubmitCallbackHandler;
+import uk.gov.hmcts.reform.iacasepaymentsapi.domain.handlers.presubmit.ErrorHandler;
+import uk.gov.hmcts.reform.iacasepaymentsapi.domain.handlers.presubmit.FeesHelper;
+import uk.gov.hmcts.reform.iacasepaymentsapi.domain.service.FeeService;
+import uk.gov.hmcts.reform.iacasepaymentsapi.infrastructure.service.ServiceRequestService;
+
+@Component
+public class SubmitAppealCreateServiceRequestHandler implements PostSubmitCallbackHandler<AsylumCase> {
+
+    private final ServiceRequestService serviceRequestService;
+    private final FeeService feeService;
+
+    private final Optional<ErrorHandler<AsylumCase>> errorHandling;
+
+    public SubmitAppealCreateServiceRequestHandler(
+        ServiceRequestService serviceRequestService,
+        FeeService feeService,
+        Optional<ErrorHandler<AsylumCase>> errorHandling) {
+        this.serviceRequestService = serviceRequestService;
+        this.feeService = feeService;
+        this.errorHandling = errorHandling;
+    }
+
+    public boolean canHandle(
+        PostSubmitCallbackStage callbackStage, Callback<AsylumCase> callback
+    ) {
+        requireNonNull(callback, "callback must not be null");
+
+        return callback.getEvent() == Event.SUBMIT_APPEAL;
+    }
+
+    public PostSubmitCallbackResponse handle(
+        PostSubmitCallbackStage callbackStage, Callback<AsylumCase> callback
+    ) {
+        if (!canHandle(callbackStage, callback)) {
+            throw new IllegalStateException("Cannot handle callback");
+        }
+
+        final AsylumCase asylumCase = callback.getCaseDetails().getCaseData();
+
+        Fee fee = FeesHelper.findFeeByHearingType(feeService, asylumCase);
+
+        if (isWaysToPay(callback, isLegalRepJourney(asylumCase))
+            && hasNoRemission(asylumCase)) {
+            try {
+                ServiceRequestResponse serviceRequestResponse = serviceRequestService
+                    .createServiceRequest(callback, fee);
+            } catch (Exception e) {
+                errorHandling.ifPresent(asylumCaseErrorHandler -> asylumCaseErrorHandler.accept(callback, e));
+            }
+        }
+        return new PostSubmitCallbackResponse();
+    }
+
+    private boolean isWaysToPay(Callback<AsylumCase> callback,
+                                boolean isLegalRepJourney) {
+
+        List<Event> waysToPayEvents = List.of(Event.SUBMIT_APPEAL,
+                                              Event.GENERATE_SERVICE_REQUEST,
+                                              Event.RECORD_REMISSION_DECISION);
+
+        return waysToPayEvents.contains(callback.getEvent())
+               && isLegalRepJourney
+               && isHuOrEaOrPa(callback.getCaseDetails().getCaseData());
+    }
+
+    private boolean isHuOrEaOrPa(AsylumCase asylumCase) {
+        Optional<AppealType> optionalAppealType = asylumCase.read(APPEAL_TYPE, AppealType.class);
+        if (optionalAppealType.isPresent()) {
+            AppealType appealType = optionalAppealType.get();
+            return appealType.equals(AppealType.EA)
+                   || appealType.equals(AppealType.HU)
+                   || appealType.equals(AppealType.PA);
+        }
+        return false;
+    }
+
+    private boolean isLegalRepJourney(AsylumCase asylumCase) {
+        return asylumCase.read(JOURNEY_TYPE, JourneyType.class)
+            .map(journey -> journey == JourneyType.REP)
+            .orElse(true);
+    }
+
+    private boolean hasNoRemission(AsylumCase asylumCase) {
+        Optional<RemissionType> optRemissionType = asylumCase.read(REMISSION_TYPE, RemissionType.class);
+        Optional<RemissionDecision> optionalRemissionDecision =
+            asylumCase.read(REMISSION_DECISION, RemissionDecision.class);
+
+        return (optRemissionType.isPresent() && optRemissionType.get() == RemissionType.NO_REMISSION)
+               || optRemissionType.isEmpty()
+               || (optionalRemissionDecision.isPresent()
+                   && optionalRemissionDecision.get() == RemissionDecision.REJECTED);
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/iacasepaymentsapi/domain/handlers/presubmit/ErrorHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasepaymentsapi/domain/handlers/presubmit/ErrorHandler.java
@@ -1,0 +1,8 @@
+package uk.gov.hmcts.reform.iacasepaymentsapi.domain.handlers.presubmit;
+
+import java.util.function.BiConsumer;
+import uk.gov.hmcts.reform.iacasepaymentsapi.domain.entities.ccd.CaseData;
+import uk.gov.hmcts.reform.iacasepaymentsapi.domain.entities.ccd.callback.Callback;
+
+public interface ErrorHandler<T extends CaseData> extends BiConsumer<Callback<T>, Throwable> {
+}

--- a/src/main/java/uk/gov/hmcts/reform/iacasepaymentsapi/domain/handlers/presubmit/FeesHelper.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasepaymentsapi/domain/handlers/presubmit/FeesHelper.java
@@ -24,7 +24,7 @@ public class FeesHelper {
     private FeesHelper() {
     }
 
-    static final Fee findFeeByHearingType(FeeService feeService, AsylumCase asylumCase) {
+    public static final Fee findFeeByHearingType(FeeService feeService, AsylumCase asylumCase) {
         Fee fee;
         Optional<String> decisionHearingFeeOption = asylumCase.read(DECISION_HEARING_FEE_OPTION, String.class);
         if (decisionHearingFeeOption.isPresent()) {

--- a/src/main/java/uk/gov/hmcts/reform/iacasepaymentsapi/domain/handlers/presubmit/PaymentAppealPreparer.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasepaymentsapi/domain/handlers/presubmit/PaymentAppealPreparer.java
@@ -148,25 +148,6 @@ public class PaymentAppealPreparer implements PreSubmitCallbackHandler<AsylumCas
             return response;
         }
 
-        YesOrNo hasServiceRequestAlready = asylumCase.read(HAS_SERVICE_REQUEST_ALREADY, YesOrNo.class)
-            .orElse(YesOrNo.NO);
-
-        if (isWaysToPay(callbackStage, callback, isLegalRepJourney(asylumCase))
-            && hasNoRemission(asylumCase)
-            && hasServiceRequestAlready != YesOrNo.YES) {
-            try {
-                ServiceRequestResponse serviceRequestResponse = serviceRequestService
-                    .createServiceRequest(callback, fee);
-                if (serviceRequestResponse.getServiceRequestReference() != null) {
-                    asylumCase.write(HAS_SERVICE_REQUEST_ALREADY, YesOrNo.YES);
-                } else {
-                    asylumCase.write(HAS_SERVICE_REQUEST_ALREADY, YesOrNo.NO);
-                }
-            } catch (Exception e) {
-                response.addErrors(Collections.singleton("Cannot create Service Request."));
-                return response;
-            }
-        }
         asylumCase.write(PAYMENT_STATUS, PAYMENT_PENDING);
 
         return new PreSubmitCallbackResponse<>(asylumCase);

--- a/src/main/java/uk/gov/hmcts/reform/iacasepaymentsapi/domain/handlers/presubmit/PaymentAppealPreparer.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasepaymentsapi/domain/handlers/presubmit/PaymentAppealPreparer.java
@@ -34,7 +34,6 @@ import uk.gov.hmcts.reform.iacasepaymentsapi.domain.entities.ccd.callback.PreSub
 import uk.gov.hmcts.reform.iacasepaymentsapi.domain.entities.ccd.callback.PreSubmitCallbackStage;
 import uk.gov.hmcts.reform.iacasepaymentsapi.domain.entities.ccd.field.YesOrNo;
 import uk.gov.hmcts.reform.iacasepaymentsapi.domain.entities.fee.Fee;
-import uk.gov.hmcts.reform.iacasepaymentsapi.domain.entities.payment.ServiceRequestResponse;
 import uk.gov.hmcts.reform.iacasepaymentsapi.domain.handlers.PreSubmitCallbackHandler;
 import uk.gov.hmcts.reform.iacasepaymentsapi.domain.service.FeeService;
 import uk.gov.hmcts.reform.iacasepaymentsapi.domain.service.RefDataService;
@@ -149,6 +148,15 @@ public class PaymentAppealPreparer implements PreSubmitCallbackHandler<AsylumCas
         }
 
         asylumCase.write(PAYMENT_STATUS, PAYMENT_PENDING);
+
+        YesOrNo hasServiceRequestAlready = asylumCase.read(HAS_SERVICE_REQUEST_ALREADY, YesOrNo.class)
+            .orElse(YesOrNo.NO);
+
+        if (isWaysToPay(callbackStage, callback, isLegalRepJourney(asylumCase))
+            && hasServiceRequestAlready != YesOrNo.YES) {
+
+            asylumCase.write(HAS_SERVICE_REQUEST_ALREADY, YesOrNo.YES);
+        }
 
         return new PreSubmitCallbackResponse<>(asylumCase);
     }

--- a/src/main/java/uk/gov/hmcts/reform/iacasepaymentsapi/infrastructure/PostSubmitCallbackDispatcher.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasepaymentsapi/infrastructure/PostSubmitCallbackDispatcher.java
@@ -1,0 +1,63 @@
+package uk.gov.hmcts.reform.iacasepaymentsapi.infrastructure;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.reform.iacasepaymentsapi.domain.entities.ccd.CaseData;
+import uk.gov.hmcts.reform.iacasepaymentsapi.domain.entities.ccd.callback.Callback;
+import uk.gov.hmcts.reform.iacasepaymentsapi.domain.entities.ccd.callback.PostSubmitCallbackResponse;
+import uk.gov.hmcts.reform.iacasepaymentsapi.domain.entities.ccd.callback.PostSubmitCallbackStage;
+import uk.gov.hmcts.reform.iacasepaymentsapi.domain.handlers.PostSubmitCallbackHandler;
+import uk.gov.hmcts.reform.iacasepaymentsapi.infrastructure.security.CcdEventAuthorizor;
+
+@Component
+public class PostSubmitCallbackDispatcher<T extends CaseData> {
+    private final CcdEventAuthorizor ccdEventAuthorizor;
+    private final List<PostSubmitCallbackHandler<T>> sortedCallbackHandlers;
+
+    public PostSubmitCallbackDispatcher(
+        CcdEventAuthorizor ccdEventAuthorizor,
+        List<PostSubmitCallbackHandler<T>> callbackHandlers
+    ) {
+        requireNonNull(ccdEventAuthorizor, "ccdEventAuthorizor must not be null");
+        requireNonNull(callbackHandlers, "callbackHandlers must not be null");
+        this.ccdEventAuthorizor = ccdEventAuthorizor;
+        this.sortedCallbackHandlers = callbackHandlers.stream()
+            // sorting handlers by handler class name
+            .sorted(Comparator.comparing(h -> h.getClass().getSimpleName()))
+            .collect(Collectors.toList());
+    }
+
+    public PostSubmitCallbackResponse handle(PostSubmitCallbackStage callbackStage,
+                                             Callback<T> callback
+    ) {
+        requireNonNull(callbackStage, "callbackStage must not be null");
+        requireNonNull(callback, "callback must not be null");
+        ccdEventAuthorizor.throwIfNotAuthorized(callback.getEvent());
+
+        PostSubmitCallbackResponse callbackResponse =
+            new PostSubmitCallbackResponse();
+
+        for (PostSubmitCallbackHandler<T> callbackHandler : sortedCallbackHandlers) {
+
+            if (callbackHandler.canHandle(callbackStage, callback)) {
+
+                PostSubmitCallbackResponse callbackResponseFromHandler =
+                    callbackHandler.handle(callbackStage, callback);
+
+                callbackResponseFromHandler
+                    .getConfirmationHeader()
+                    .ifPresent(callbackResponse::setConfirmationHeader);
+
+                callbackResponseFromHandler
+                    .getConfirmationBody()
+                    .ifPresent(callbackResponse::setConfirmationBody);
+            }
+        }
+
+        return callbackResponse;
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/iacasepaymentsapi/infrastructure/controllers/PostSubmitCallbackController.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasepaymentsapi/infrastructure/controllers/PostSubmitCallbackController.java
@@ -1,0 +1,108 @@
+package uk.gov.hmcts.reform.iacasepaymentsapi.infrastructure.controllers;
+
+import static java.util.Objects.requireNonNull;
+import static org.springframework.http.ResponseEntity.ok;
+
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
+import io.swagger.annotations.Authorization;
+import javax.validation.constraints.NotNull;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import uk.gov.hmcts.reform.iacasepaymentsapi.domain.entities.AsylumCase;
+import uk.gov.hmcts.reform.iacasepaymentsapi.domain.entities.ccd.callback.*;
+import uk.gov.hmcts.reform.iacasepaymentsapi.infrastructure.PostSubmitCallbackDispatcher;
+
+@Api(
+    value = "Handles 'SubmittedEvent' callbacks from CCD",
+    consumes = MediaType.APPLICATION_JSON_VALUE,
+    produces = MediaType.APPLICATION_JSON_VALUE
+)
+@RequestMapping(
+    path = "/asylum",
+    consumes = MediaType.APPLICATION_JSON_VALUE,
+    produces = MediaType.APPLICATION_JSON_VALUE
+)
+@RestController
+@Slf4j
+public class PostSubmitCallbackController {
+
+    private final PostSubmitCallbackDispatcher<AsylumCase> callbackDispatcher;
+
+    public PostSubmitCallbackController(
+        PostSubmitCallbackDispatcher<AsylumCase> callbackDispatcher
+    ) {
+        requireNonNull(callbackDispatcher, "callbackDispatcher must not be null");
+
+        this.callbackDispatcher = callbackDispatcher;
+    }
+
+    @ApiOperation(
+        value = "Handles 'CcdSubmitted' callbacks from CCD",
+        authorizations = {
+            @Authorization(value = "Authorization"),
+            @Authorization(value = "ServiceAuthorization")
+        }
+    )
+    @ApiResponses({
+        @ApiResponse(
+            code = 200,
+            message = "Optional confirmation text for CCD",
+            response = PreSubmitCallbackResponse.class
+        ),
+        @ApiResponse(
+            code = 400,
+            message = "Bad Request"
+        ),
+        @ApiResponse(
+            code = 401,
+            message = "An error occurred while attempting to decode the Jwt: Invalid token"
+        ),
+        @ApiResponse(
+            code = 415,
+            message = "Unsupported Media Type"
+        ),
+        @ApiResponse(
+            code = 500,
+            message = "Internal Server Error"
+        )
+    })
+    @PostMapping(path = "/ccdSubmitted")
+    public ResponseEntity<PostSubmitCallbackResponse> ccdSubmitted(
+        @ApiParam(value = "Asylum case data", required = true) @NotNull @RequestBody Callback<AsylumCase> callback
+    ) {
+        return performStageRequest(PostSubmitCallbackStage.CCD_SUBMITTED, callback);
+    }
+
+    private ResponseEntity<PostSubmitCallbackResponse> performStageRequest(
+        PostSubmitCallbackStage callbackStage,
+        Callback<AsylumCase> callback
+    ) {
+
+        log.info(
+            "Asylum Case Payments API `ccdSubmitted` event `{}` received for Case ID `{}`",
+            callback.getEvent(),
+            callback.getCaseDetails().getId()
+        );
+
+        PostSubmitCallbackResponse callbackResponse =
+            callbackDispatcher.handle(callbackStage, callback);
+
+        log.info(
+            "Asylum Case Payments API `ccdSubmitted` event `{}` received for Case ID `{}`",
+            callback.getEvent(),
+            callback.getCaseDetails().getId()
+        );
+
+        return ok(callbackResponse);
+    }
+}
+

--- a/src/main/java/uk/gov/hmcts/reform/iacasepaymentsapi/infrastructure/controllers/PostSubmitCallbackController.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasepaymentsapi/infrastructure/controllers/PostSubmitCallbackController.java
@@ -18,7 +18,9 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import uk.gov.hmcts.reform.iacasepaymentsapi.domain.entities.AsylumCase;
-import uk.gov.hmcts.reform.iacasepaymentsapi.domain.entities.ccd.callback.*;
+import uk.gov.hmcts.reform.iacasepaymentsapi.domain.entities.ccd.callback.Callback;
+import uk.gov.hmcts.reform.iacasepaymentsapi.domain.entities.ccd.callback.PostSubmitCallbackResponse;
+import uk.gov.hmcts.reform.iacasepaymentsapi.domain.entities.ccd.callback.PostSubmitCallbackStage;
 import uk.gov.hmcts.reform.iacasepaymentsapi.infrastructure.PostSubmitCallbackDispatcher;
 
 @Api(
@@ -56,7 +58,7 @@ public class PostSubmitCallbackController {
         @ApiResponse(
             code = 200,
             message = "Optional confirmation text for CCD",
-            response = PreSubmitCallbackResponse.class
+            response = PostSubmitCallbackResponse.class
         ),
         @ApiResponse(
             code = 400,

--- a/src/test/java/uk/gov/hmcts/reform/iacasepaymentsapi/domain/entities/ccd/callback/PostSubmitCallbackResponseTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacasepaymentsapi/domain/entities/ccd/callback/PostSubmitCallbackResponseTest.java
@@ -1,0 +1,45 @@
+package uk.gov.hmcts.reform.iacasepaymentsapi.domain.entities.ccd.callback;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class PostSubmitCallbackResponseTest {
+
+    private PostSubmitCallbackResponse postSubmitCallbackResponse =
+        new PostSubmitCallbackResponse();
+
+    @Test
+    void should_store_confirmation() {
+
+        assertFalse(postSubmitCallbackResponse.getConfirmationHeader().isPresent());
+        assertFalse(postSubmitCallbackResponse.getConfirmationBody().isPresent());
+
+        String expectedConfirmationHeader = "header";
+        String expectedConfirmationBody = "body";
+
+        postSubmitCallbackResponse.setConfirmationHeader(expectedConfirmationHeader);
+        postSubmitCallbackResponse.setConfirmationBody(expectedConfirmationBody);
+
+        assertEquals(Optional.of(expectedConfirmationHeader), postSubmitCallbackResponse.getConfirmationHeader());
+        assertEquals(Optional.of(expectedConfirmationBody), postSubmitCallbackResponse.getConfirmationBody());
+    }
+
+    @Test
+    void should_convert_null_values_to_empty_optional() {
+
+        assertFalse(postSubmitCallbackResponse.getConfirmationHeader().isPresent());
+        assertFalse(postSubmitCallbackResponse.getConfirmationBody().isPresent());
+
+        postSubmitCallbackResponse.setConfirmationHeader(null);
+        postSubmitCallbackResponse.setConfirmationBody(null);
+
+        assertFalse(postSubmitCallbackResponse.getConfirmationHeader().isPresent());
+        assertFalse(postSubmitCallbackResponse.getConfirmationBody().isPresent());
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/iacasepaymentsapi/domain/entities/ccd/callback/PostSubmitCallbackStageTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacasepaymentsapi/domain/entities/ccd/callback/PostSubmitCallbackStageTest.java
@@ -1,0 +1,21 @@
+package uk.gov.hmcts.reform.iacasepaymentsapi.domain.entities.ccd.callback;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class PostSubmitCallbackStageTest {
+
+    @Test
+    void has_correct_case_event_ids() {
+        assertEquals("ccdSubmitted", PostSubmitCallbackStage.CCD_SUBMITTED.toString());
+    }
+
+    @Test
+    void if_this_test_fails_it_is_because_it_needs_updating_with_your_changes() {
+        assertEquals(1, PostSubmitCallbackStage.values().length);
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/iacasepaymentsapi/domain/handlers/postsubmit/SubmitAppealCreateServiceRequestHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacasepaymentsapi/domain/handlers/postsubmit/SubmitAppealCreateServiceRequestHandlerTest.java
@@ -1,0 +1,180 @@
+package uk.gov.hmcts.reform.iacasepaymentsapi.domain.handlers.postsubmit;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static uk.gov.hmcts.reform.iacasepaymentsapi.domain.entities.AsylumCaseDefinition.APPEAL_TYPE;
+import static uk.gov.hmcts.reform.iacasepaymentsapi.domain.entities.AsylumCaseDefinition.DECISION_HEARING_FEE_OPTION;
+import static uk.gov.hmcts.reform.iacasepaymentsapi.domain.entities.AsylumCaseDefinition.JOURNEY_TYPE;
+import static uk.gov.hmcts.reform.iacasepaymentsapi.domain.entities.AsylumCaseDefinition.REMISSION_DECISION;
+import static uk.gov.hmcts.reform.iacasepaymentsapi.domain.entities.AsylumCaseDefinition.REMISSION_TYPE;
+import static uk.gov.hmcts.reform.iacasepaymentsapi.domain.entities.RemissionType.NO_REMISSION;
+
+import java.math.BigDecimal;
+import java.util.Arrays;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.hmcts.reform.iacasepaymentsapi.domain.entities.AppealType;
+import uk.gov.hmcts.reform.iacasepaymentsapi.domain.entities.AsylumCase;
+import uk.gov.hmcts.reform.iacasepaymentsapi.domain.entities.JourneyType;
+import uk.gov.hmcts.reform.iacasepaymentsapi.domain.entities.RemissionDecision;
+import uk.gov.hmcts.reform.iacasepaymentsapi.domain.entities.RemissionType;
+import uk.gov.hmcts.reform.iacasepaymentsapi.domain.entities.ccd.CaseDetails;
+import uk.gov.hmcts.reform.iacasepaymentsapi.domain.entities.ccd.Event;
+import uk.gov.hmcts.reform.iacasepaymentsapi.domain.entities.ccd.callback.Callback;
+import uk.gov.hmcts.reform.iacasepaymentsapi.domain.entities.ccd.callback.PostSubmitCallbackResponse;
+import uk.gov.hmcts.reform.iacasepaymentsapi.domain.entities.ccd.callback.PostSubmitCallbackStage;
+import uk.gov.hmcts.reform.iacasepaymentsapi.domain.entities.fee.Fee;
+import uk.gov.hmcts.reform.iacasepaymentsapi.domain.entities.fee.FeeType;
+import uk.gov.hmcts.reform.iacasepaymentsapi.domain.entities.payment.ServiceRequestResponse;
+import uk.gov.hmcts.reform.iacasepaymentsapi.domain.handlers.presubmit.ErrorHandler;
+import uk.gov.hmcts.reform.iacasepaymentsapi.domain.service.FeeService;
+import uk.gov.hmcts.reform.iacasepaymentsapi.infrastructure.service.ServiceRequestService;
+
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("unchecked")
+class SubmitAppealCreateServiceRequestHandlerTest {
+
+    @Mock private Callback<AsylumCase> callback;
+    @Mock private CaseDetails<AsylumCase> caseDetails;
+    @Mock private AsylumCase asylumCase;
+    @Mock private FeeService feeService;
+    @Mock private ServiceRequestService serviceRequestService;
+    @Mock private ServiceRequestResponse serviceRequestResponse;
+
+    @Mock private ErrorHandler<AsylumCase> errorHandling;
+
+    private SubmitAppealCreateServiceRequestHandler submitAppealCreateServiceRequestHandler;
+
+    @BeforeEach
+    public void setUp() {
+        submitAppealCreateServiceRequestHandler =
+            new SubmitAppealCreateServiceRequestHandler(serviceRequestService, feeService, Optional.of(errorHandling)
+        );
+
+        lenient().when(callback.getCaseDetails()).thenReturn(caseDetails);
+        lenient().when(caseDetails.getCaseData()).thenReturn(asylumCase);
+        lenient().when(asylumCase.read(JOURNEY_TYPE, JourneyType.class)).thenReturn(Optional.of(JourneyType.REP));
+    }
+
+    @Test
+    void should_generate_service_request_when_can_handle_ea_appeal() throws Exception {
+
+        when(callback.getEvent()).thenReturn(Event.SUBMIT_APPEAL);
+        when(asylumCase.read(APPEAL_TYPE, AppealType.class)).thenReturn(Optional.of(AppealType.EA));
+        when(asylumCase.read(REMISSION_TYPE, RemissionType.class)).thenReturn(Optional.of(NO_REMISSION));
+        when(asylumCase.read(REMISSION_DECISION, RemissionDecision.class))
+            .thenReturn(Optional.empty());
+
+        Fee feeWithHearing =
+            new Fee("FEE0001", "Fee with hearing", "1", new BigDecimal("140"));
+        when(asylumCase.read(DECISION_HEARING_FEE_OPTION, String.class)).thenReturn(Optional.of("decisionWithHearing"));
+        when(feeService.getFee(FeeType.FEE_WITH_HEARING)).thenReturn(feeWithHearing);
+        when(serviceRequestService.createServiceRequest(callback, feeWithHearing)).thenReturn(serviceRequestResponse);
+
+        PostSubmitCallbackResponse callbackResponse =
+            submitAppealCreateServiceRequestHandler.handle(PostSubmitCallbackStage.CCD_SUBMITTED, callback);
+
+        assertNotNull(callbackResponse);
+        verify(serviceRequestService, times(1)).createServiceRequest(callback, feeWithHearing);
+    }
+
+    @Test
+    void should_generate_service_request_when_can_handle_hu_appeal() throws Exception {
+
+        when(callback.getEvent()).thenReturn(Event.SUBMIT_APPEAL);
+        when(asylumCase.read(APPEAL_TYPE, AppealType.class)).thenReturn(Optional.of(AppealType.HU));
+        when(asylumCase.read(REMISSION_TYPE, RemissionType.class)).thenReturn(Optional.of(NO_REMISSION));
+        when(asylumCase.read(REMISSION_DECISION, RemissionDecision.class))
+            .thenReturn(Optional.empty());
+
+        Fee feeWithHearing =
+            new Fee("FEE0001", "Fee with hearing", "1", new BigDecimal("140"));
+        when(asylumCase.read(DECISION_HEARING_FEE_OPTION, String.class)).thenReturn(Optional.of("decisionWithHearing"));
+        when(feeService.getFee(FeeType.FEE_WITH_HEARING)).thenReturn(feeWithHearing);
+        when(serviceRequestService.createServiceRequest(callback, feeWithHearing)).thenReturn(serviceRequestResponse);
+
+        PostSubmitCallbackResponse callbackResponse =
+            submitAppealCreateServiceRequestHandler.handle(PostSubmitCallbackStage.CCD_SUBMITTED, callback);
+
+        assertNotNull(callbackResponse);
+        verify(serviceRequestService, times(1)).createServiceRequest(callback, feeWithHearing);
+    }
+
+    @Test
+    void should_generate_service_request_when_can_handle_pa_appeal() throws Exception {
+
+        when(callback.getEvent()).thenReturn(Event.SUBMIT_APPEAL);
+        when(asylumCase.read(APPEAL_TYPE, AppealType.class)).thenReturn(Optional.of(AppealType.PA));
+        when(asylumCase.read(REMISSION_TYPE, RemissionType.class)).thenReturn(Optional.of(NO_REMISSION));
+        when(asylumCase.read(REMISSION_DECISION, RemissionDecision.class))
+            .thenReturn(Optional.empty());
+
+        Fee feeWithHearing =
+            new Fee("FEE0001", "Fee with hearing", "1", new BigDecimal("140"));
+        when(asylumCase.read(DECISION_HEARING_FEE_OPTION, String.class)).thenReturn(Optional.of("decisionWithHearing"));
+        when(feeService.getFee(FeeType.FEE_WITH_HEARING)).thenReturn(feeWithHearing);
+        when(serviceRequestService.createServiceRequest(callback, feeWithHearing)).thenReturn(serviceRequestResponse);
+
+        PostSubmitCallbackResponse callbackResponse =
+            submitAppealCreateServiceRequestHandler.handle(PostSubmitCallbackStage.CCD_SUBMITTED, callback);
+
+        assertNotNull(callbackResponse);
+        verify(serviceRequestService, times(1)).createServiceRequest(callback, feeWithHearing);
+    }
+
+    @Test
+    void handling_should_throw_if_cannot_actually_handle() {
+
+        when(callback.getEvent()).thenReturn(Event.START_APPEAL);
+        assertThatThrownBy(() -> submitAppealCreateServiceRequestHandler
+            .handle(PostSubmitCallbackStage.CCD_SUBMITTED, callback))
+            .isExactlyInstanceOf(IllegalStateException.class)
+            .hasMessage("Cannot handle callback");
+    }
+
+    @Test
+    void it_can_handle_callback() {
+
+        for (Event event : Event.values()) {
+
+            when(callback.getEvent()).thenReturn(event);
+
+            for (PostSubmitCallbackStage callbackStage : PostSubmitCallbackStage.values()) {
+
+                boolean canHandle = submitAppealCreateServiceRequestHandler.canHandle(callbackStage, callback);
+
+                if ((Arrays.asList(
+                    Event.SUBMIT_APPEAL,
+                    Event.GENERATE_SERVICE_REQUEST,
+                    Event.RECORD_REMISSION_DECISION).contains(callback.getEvent())
+                     && callbackStage == PostSubmitCallbackStage.CCD_SUBMITTED)
+                    || isWaysToPay(callbackStage, callback, true)) {
+
+                    assertTrue(canHandle);
+                } else {
+                    assertFalse(canHandle);
+                }
+            }
+        }
+    }
+
+    private boolean isWaysToPay(PostSubmitCallbackStage callbackStage,
+                                Callback<AsylumCase> callback,
+                                boolean isLegalRepJourney) {
+        return callbackStage == PostSubmitCallbackStage.CCD_SUBMITTED
+               && (callback.getEvent() == Event.SUBMIT_APPEAL
+                   || callback.getEvent() == Event.GENERATE_SERVICE_REQUEST
+                   || callback.getEvent() == Event.RECORD_REMISSION_DECISION)
+               && isLegalRepJourney;
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/iacasepaymentsapi/domain/handlers/presubmit/PaymentAppealPreparerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacasepaymentsapi/domain/handlers/presubmit/PaymentAppealPreparerTest.java
@@ -59,7 +59,6 @@ import uk.gov.hmcts.reform.iacasepaymentsapi.domain.entities.fee.Fee;
 import uk.gov.hmcts.reform.iacasepaymentsapi.domain.entities.fee.FeeType;
 import uk.gov.hmcts.reform.iacasepaymentsapi.domain.entities.fee.OrganisationEntityResponse;
 import uk.gov.hmcts.reform.iacasepaymentsapi.domain.entities.fee.OrganisationResponse;
-import uk.gov.hmcts.reform.iacasepaymentsapi.domain.entities.payment.ServiceRequestResponse;
 import uk.gov.hmcts.reform.iacasepaymentsapi.domain.service.FeeService;
 import uk.gov.hmcts.reform.iacasepaymentsapi.domain.service.RefDataService;
 import uk.gov.hmcts.reform.iacasepaymentsapi.infrastructure.service.ServiceRequestService;
@@ -76,7 +75,6 @@ class PaymentAppealPreparerTest {
     @Mock private ServiceRequestService serviceRequestService;
     @Mock private OrganisationEntityResponse organisationEntityResponse;
     @Mock private OrganisationResponse organisationResponse;
-    @Mock private ServiceRequestResponse serviceRequestResponse;
 
     private PaymentAppealPreparer paymentAppealPreparer;
 
@@ -429,7 +427,7 @@ class PaymentAppealPreparerTest {
     }
 
     @Test
-    void should_send_request_for_service_request_if_is_ways_to_pay_submit_appeal() throws Exception {
+    void should_send_request_for_service_request_if_is_ways_to_pay_submit_appeal() {
         when(callback.getEvent()).thenReturn(Event.SUBMIT_APPEAL);
         when(refDataService.getOrganisationResponse())
             .thenReturn(organisationResponse);
@@ -452,13 +450,12 @@ class PaymentAppealPreparerTest {
         PreSubmitCallbackResponse<AsylumCase> callbackResponse = paymentAppealPreparer
             .handle(PreSubmitCallbackStage.ABOUT_TO_SUBMIT, callback);
         assertThat(callbackResponse.getData()).isEqualTo(asylumCase);
-
-        verify(serviceRequestService, times(1)).createServiceRequest(callback, feeWithHearing);
+        verify(asylumCase, times(1)).write(HAS_SERVICE_REQUEST_ALREADY, YesOrNo.YES);
 
     }
 
     @Test
-    void should_send_request_for_service_request_if_is_ways_to_pay_generate_service_request() throws Exception {
+    void should_send_request_for_service_request_if_is_ways_to_pay_generate_service_request() {
         when(callback.getEvent()).thenReturn(Event.GENERATE_SERVICE_REQUEST);
         when(refDataService.getOrganisationResponse())
             .thenReturn(organisationResponse);
@@ -477,16 +474,10 @@ class PaymentAppealPreparerTest {
             new Fee("FEE0001", "Fee with hearing", "1", new BigDecimal("140"));
         when(asylumCase.read(DECISION_HEARING_FEE_OPTION, String.class)).thenReturn(Optional.of("decisionWithHearing"));
         when(feeService.getFee(FeeType.FEE_WITH_HEARING)).thenReturn(feeWithHearing);
-        when(asylumCase.read(HAS_SERVICE_REQUEST_ALREADY, YesOrNo.class)).thenReturn(Optional.of(YesOrNo.NO));
-        when(serviceRequestService.createServiceRequest(callback, feeWithHearing)).thenReturn(serviceRequestResponse);
-        when(serviceRequestResponse.getServiceRequestReference()).thenReturn("1234ABCD");
 
         PreSubmitCallbackResponse<AsylumCase> callbackResponse = paymentAppealPreparer
             .handle(PreSubmitCallbackStage.ABOUT_TO_SUBMIT, callback);
         assertThat(callbackResponse.getData()).isEqualTo(asylumCase);
-
-        verify(serviceRequestService, times(1)).createServiceRequest(callback, feeWithHearing);
-
         verify(asylumCase, times(1)).write(HAS_SERVICE_REQUEST_ALREADY, YesOrNo.YES);
     }
 

--- a/src/test/java/uk/gov/hmcts/reform/iacasepaymentsapi/infrastructure/PostSubmitCallbackDispatcherTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacasepaymentsapi/infrastructure/PostSubmitCallbackDispatcherTest.java
@@ -1,0 +1,223 @@
+package uk.gov.hmcts.reform.iacasepaymentsapi.infrastructure;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.security.access.AccessDeniedException;
+import uk.gov.hmcts.reform.iacasepaymentsapi.domain.entities.ccd.CaseData;
+import uk.gov.hmcts.reform.iacasepaymentsapi.domain.entities.ccd.CaseDetails;
+import uk.gov.hmcts.reform.iacasepaymentsapi.domain.entities.ccd.Event;
+import uk.gov.hmcts.reform.iacasepaymentsapi.domain.entities.ccd.callback.Callback;
+import uk.gov.hmcts.reform.iacasepaymentsapi.domain.entities.ccd.callback.PostSubmitCallbackResponse;
+import uk.gov.hmcts.reform.iacasepaymentsapi.domain.entities.ccd.callback.PostSubmitCallbackStage;
+import uk.gov.hmcts.reform.iacasepaymentsapi.domain.handlers.PostSubmitCallbackHandler;
+import uk.gov.hmcts.reform.iacasepaymentsapi.infrastructure.security.CcdEventAuthorizor;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@SuppressWarnings("unchecked")
+class PostSubmitCallbackDispatcherTest {
+
+    @Mock
+    private CcdEventAuthorizor ccdEventAuthorizor;
+    @Mock
+    private PostSubmitCallbackHandler<CaseData> handler1;
+    @Mock
+    private PostSubmitCallbackHandler<CaseData> handler2;
+    @Mock
+    private PostSubmitCallbackHandler<CaseData> handler3;
+    @Mock
+    private Callback<CaseData> callback;
+    @Mock
+    private CaseDetails<CaseData> caseDetails;
+    @Mock
+    private CaseData caseData;
+
+
+    private String header1 = "Some header 1";
+    private String body1 = "Some body 1";
+
+    private String header2 = "Some header 2";
+    private String body2 = "Some body 2";
+
+    private String header3 = "Some header 3";
+    private String body3 = "Some body 3";
+
+
+    @Mock
+    private PostSubmitCallbackResponse response1;
+    @Mock
+    private PostSubmitCallbackResponse response2;
+    @Mock
+    private PostSubmitCallbackResponse response3;
+
+    private PostSubmitCallbackDispatcher<CaseData> postSubmitCallbackDispatcher;
+
+    @BeforeEach
+    public void setUp() {
+        postSubmitCallbackDispatcher = new PostSubmitCallbackDispatcher<>(
+            ccdEventAuthorizor,
+            Arrays.asList(
+                handler1,
+                handler2,
+                handler3
+            )
+        );
+    }
+
+    @Test
+    void should_only_dispatch_callback_to_handlers_that_can_handle_it() {
+
+        for (PostSubmitCallbackStage callbackStage : PostSubmitCallbackStage.values()) {
+
+            when(callback.getEvent()).thenReturn(Event.SUBMIT_APPEAL);
+            when(callback.getCaseDetails()).thenReturn(caseDetails);
+            when(caseDetails.getCaseData()).thenReturn(caseData);
+
+            when(response1.getConfirmationHeader()).thenReturn(Optional.of(header1));
+            when(response1.getConfirmationBody()).thenReturn(Optional.of(body1));
+
+            when(response2.getConfirmationHeader()).thenReturn(Optional.of(header2));
+            when(response2.getConfirmationBody()).thenReturn(Optional.of(body2));
+
+            when(response3.getConfirmationHeader()).thenReturn(Optional.of(header3));
+            when(response3.getConfirmationBody()).thenReturn(Optional.of(body3));
+
+            when(handler1.canHandle(eq(callbackStage), any(Callback.class))).thenReturn(false);
+            when(handler1.handle(eq(callbackStage), any(Callback.class))).thenReturn(response1);
+
+            when(handler2.canHandle(eq(callbackStage), any(Callback.class))).thenReturn(false);
+            when(handler2.handle(eq(callbackStage), any(Callback.class))).thenReturn(response2);
+
+            when(handler3.canHandle(eq(callbackStage), any(Callback.class))).thenReturn(true);
+            when(handler3.handle(eq(callbackStage), any(Callback.class))).thenReturn(response3);
+
+            PostSubmitCallbackResponse callbackResponse =
+                postSubmitCallbackDispatcher.handle(callbackStage, callback);
+
+            assertNotNull(callbackResponse);
+            //assertEquals(caseData, callbackResponse.getData());
+            assertEquals(Optional.of(body3), callbackResponse.getConfirmationBody());
+            //assertTrue(callbackResponse.getErrors().isEmpty());
+
+            verify(ccdEventAuthorizor, times(1)).throwIfNotAuthorized(Event.SUBMIT_APPEAL);
+
+            verify(handler1, times(1)).canHandle(eq(callbackStage), any(Callback.class));
+            verify(handler1, times(0)).handle(eq(callbackStage), any(Callback.class));
+
+            verify(handler2, times(1)).canHandle(eq(callbackStage), any(Callback.class));
+            verify(handler2, times(0)).handle(eq(callbackStage), any(Callback.class));
+
+            verify(handler3, times(1)).canHandle(eq(callbackStage), any(Callback.class));
+            verify(handler3, times(1)).handle(eq(callbackStage), any(Callback.class));
+
+            reset(ccdEventAuthorizor, handler1, handler2, handler3);
+        }
+    }
+
+    @Test
+    void should_not_dispatch_to_handlers_if_user_not_authorized_for_event() {
+
+        for (PostSubmitCallbackStage callbackStage : PostSubmitCallbackStage.values()) {
+
+            when(callback.getEvent()).thenReturn(Event.SUBMIT_APPEAL);
+
+            doThrow(AccessDeniedException.class)
+                .when(ccdEventAuthorizor)
+                .throwIfNotAuthorized(Event.SUBMIT_APPEAL);
+
+            assertThatThrownBy(() -> postSubmitCallbackDispatcher.handle(callbackStage, callback))
+                .isExactlyInstanceOf(AccessDeniedException.class);
+
+            verify(ccdEventAuthorizor, times(1)).throwIfNotAuthorized(Event.SUBMIT_APPEAL);
+
+            verify(handler1, never()).canHandle(any(), any());
+            verify(handler1, never()).handle(any(), any());
+            verify(handler2, never()).canHandle(any(), any());
+            verify(handler2, never()).handle(any(), any());
+            verify(handler3, never()).canHandle(any(), any());
+            verify(handler3, never()).handle(any(), any());
+
+            reset(ccdEventAuthorizor, handler1, handler2, handler3);
+        }
+    }
+
+    @Test
+    void should_not_error_if_no_handlers_are_provided() {
+
+        PostSubmitCallbackDispatcher<CaseData> postSubmitCallbackDispatcher =
+            new PostSubmitCallbackDispatcher<>(ccdEventAuthorizor, Collections.emptyList());
+
+        for (PostSubmitCallbackStage callbackStage : PostSubmitCallbackStage.values()) {
+
+            try {
+
+                when(callback.getEvent()).thenReturn(Event.SUBMIT_APPEAL);
+                when(callback.getCaseDetails()).thenReturn(caseDetails);
+                when(caseDetails.getCaseData()).thenReturn(caseData);
+
+                PostSubmitCallbackResponse callbackResponse =
+                    postSubmitCallbackDispatcher
+                        .handle(callbackStage, callback);
+
+                assertNotNull(callbackResponse);
+
+                verify(ccdEventAuthorizor, times(1)).throwIfNotAuthorized(Event.SUBMIT_APPEAL);
+
+                reset(ccdEventAuthorizor);
+
+            } catch (Exception e) {
+                fail("Should not have thrown any exception");
+            }
+        }
+    }
+
+    @Test
+    void should_not_allow_null_ccd_event_authorizor() {
+        List<PostSubmitCallbackHandler<CaseData>> postSubmitCallbackHandlers = Collections.emptyList();
+        assertThatThrownBy(() -> new PostSubmitCallbackDispatcher<>(null, postSubmitCallbackHandlers))
+            .hasMessage("ccdEventAuthorizor must not be null")
+            .isExactlyInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void should_not_allow_null_handlers() {
+
+        assertThatThrownBy(() -> new PostSubmitCallbackDispatcher<>(ccdEventAuthorizor, null))
+            .hasMessage("callbackHandlers must not be null")
+            .isExactlyInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void should_not_allow_null_arguments() {
+
+        assertThatThrownBy(() -> postSubmitCallbackDispatcher.handle(null, callback))
+            .hasMessage("callbackStage must not be null")
+            .isExactlyInstanceOf(NullPointerException.class);
+
+        assertThatThrownBy(() -> postSubmitCallbackDispatcher.handle(PostSubmitCallbackStage.CCD_SUBMITTED, null))
+            .hasMessage("callback must not be null")
+            .isExactlyInstanceOf(NullPointerException.class);
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/iacasepaymentsapi/infrastructure/controllers/PostSubmitCallbackControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacasepaymentsapi/infrastructure/controllers/PostSubmitCallbackControllerTest.java
@@ -1,0 +1,70 @@
+package uk.gov.hmcts.reform.iacasepaymentsapi.infrastructure.controllers;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.ResponseEntity;
+import uk.gov.hmcts.reform.iacasepaymentsapi.domain.entities.AsylumCase;
+import uk.gov.hmcts.reform.iacasepaymentsapi.domain.entities.ccd.CaseDetails;
+import uk.gov.hmcts.reform.iacasepaymentsapi.domain.entities.ccd.callback.Callback;
+import uk.gov.hmcts.reform.iacasepaymentsapi.domain.entities.ccd.callback.PostSubmitCallbackResponse;
+import uk.gov.hmcts.reform.iacasepaymentsapi.domain.entities.ccd.callback.PostSubmitCallbackStage;
+import uk.gov.hmcts.reform.iacasepaymentsapi.infrastructure.PostSubmitCallbackDispatcher;
+
+@ExtendWith(MockitoExtension.class)
+class PostSubmitCallbackControllerTest {
+
+    @Mock
+    private PostSubmitCallbackDispatcher<AsylumCase> callbackDispatcher;
+    @Mock
+    private PostSubmitCallbackResponse callbackResponse;
+    @Mock
+    private Callback<AsylumCase> callback;
+    @Mock
+    private CaseDetails<AsylumCase> caseDetails;
+    private PostSubmitCallbackStage callbackStage = PostSubmitCallbackStage.CCD_SUBMITTED;
+
+    private PostSubmitCallbackController postSubmitCallbackController;
+
+    @BeforeEach
+    public void setUp() {
+        postSubmitCallbackController =
+            new PostSubmitCallbackController(
+                callbackDispatcher
+            );
+    }
+
+    @Test
+    void should_dispatch_callback_then_return_response() {
+
+        when(callback.getCaseDetails()).thenReturn(caseDetails);
+
+        doReturn(callbackResponse)
+            .when(callbackDispatcher)
+            .handle(callbackStage, callback);
+
+        ResponseEntity<PostSubmitCallbackResponse> actualResponse =
+            postSubmitCallbackController.ccdSubmitted(callback);
+
+        assertNotNull(actualResponse);
+
+        verify(callbackDispatcher, times(1)).handle(callbackStage, callback);
+    }
+
+    @Test
+    void should_not_allow_null_constructor_arguments() {
+
+        assertThatThrownBy(() -> new PostSubmitCallbackController(null))
+            .hasMessage("callbackDispatcher must not be null")
+            .isExactlyInstanceOf(NullPointerException.class);
+    }
+}


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RIA-6161

### Change description ###

- Added classes for PostSubmit callbacks on /ccdSubmitted endpoint
- Removed service request generation from PaymentAppealPreparer and moved to a PostSubmit handler class, so generation only happens upon successful event completion
- Added unit tests and modified existing unit tests

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
