### PR TITLE
RIA-7028 Added check for recordRemissionDecision event to not write p…

### DIFF
--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -34,15 +34,15 @@
     <cve>CVE-2022-38752</cve>
     <cve>CVE-2022-42003</cve>
     <cve>CVE-2022-42004</cve>
-  </suppress>  
-  <suppress>  
+  </suppress>
+  <suppress>
         <cve>CVE-2022-31690</cve>
 	<cve>CVE-2022-31692</cve>
         <cve>CVE-2022-42252</cve>
-	<cve>CVE-2021-37533</cve>	
+	<cve>CVE-2021-37533</cve>
 	<cve>CVE-2022-45143</cve>
     </suppress>
-  <suppress until="2023-04-18">
+  <suppress until="2023-04-20">
         <cve>CVE-2022-45688</cve>
         <cve>CVE-2022-1471</cve>
         <cve>CVE-2023-20861</cve>

--- a/src/main/java/uk/gov/hmcts/reform/iacasepaymentsapi/domain/handlers/presubmit/PaymentAppealPreparer.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasepaymentsapi/domain/handlers/presubmit/PaymentAppealPreparer.java
@@ -152,7 +152,11 @@ public class PaymentAppealPreparer implements PreSubmitCallbackHandler<AsylumCas
             return response;
         }
 
-        asylumCase.write(PAYMENT_STATUS, PAYMENT_PENDING);
+        if (callback.getEvent() != Event.RECORD_REMISSION_DECISION
+            || (callback.getEvent() == Event.RECORD_REMISSION_DECISION
+                && asylumCase.read(PAYMENT_STATUS).isEmpty())) {
+            asylumCase.write(PAYMENT_STATUS, PAYMENT_PENDING);
+        }
 
         YesOrNo hasServiceRequestAlready = asylumCase.read(HAS_SERVICE_REQUEST_ALREADY, YesOrNo.class)
             .orElse(YesOrNo.NO);


### PR DESCRIPTION
…aymentStatus if exist

### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RIA-7028


### Change description ###
Added check for recordRemissionDecision event to not write paymentStatus if exist


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x ] No
```
