### PR TITLE
RIA-7378 - preventing application startup if secrets can't be found

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -35,7 +35,8 @@ def secrets = [
         secret('idam-client-id', 'IA_IDAM_CLIENT_ID'),
         secret('idam-secret', 'IA_IDAM_SECRET'),
         secret('s2s-secret', 'IA_S2S_SECRET'),
-        secret('s2s-microservice', 'IA_S2S_MICROSERVICE')
+        secret('s2s-microservice', 'IA_S2S_MICROSERVICE'),
+        secret('ia-config-validator-secret', 'IA_CONFIG_VALIDATOR_SECRET')
 
     ]
 ]

--- a/Jenkinsfile_nightly
+++ b/Jenkinsfile_nightly
@@ -39,7 +39,8 @@ def secrets = [
     secret('idam-client-id', 'IA_IDAM_CLIENT_ID'),
     secret('idam-secret', 'IA_IDAM_SECRET'),
     secret('s2s-secret', 'IA_S2S_SECRET'),
-    secret('s2s-microservice', 'IA_S2S_MICROSERVICE')
+    secret('s2s-microservice', 'IA_S2S_MICROSERVICE'),
+    secret('ia-config-validator-secret', 'IA_CONFIG_VALIDATOR_SECRET')
 
   ]
 ]

--- a/charts/ia-case-payments-api/Chart.yaml
+++ b/charts/ia-case-payments-api/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "1.0"
 description: A Helm chart for Case Payments API App
 name: ia-case-payments-api
 home: https://github.com/hmcts/ia-case-payments-api
-version: 0.0.16
+version: 0.0.17
 maintainers:
   - name: Immigration & Asylum Team
 dependencies:

--- a/charts/ia-case-payments-api/values.preview.template.yaml
+++ b/charts/ia-case-payments-api/values.preview.template.yaml
@@ -19,3 +19,4 @@ java:
         - s2s-secret
         - s2s-microservice
         - AppInsightsInstrumentationKey
+        - ia-config-validator-secret

--- a/charts/ia-case-payments-api/values.yaml
+++ b/charts/ia-case-payments-api/values.yaml
@@ -23,3 +23,4 @@ java:
         - AppInsightsInstrumentationKey
         - system-username
         - system-password
+        - ia-config-validator-secret

--- a/src/main/java/uk/gov/hmcts/reform/iacasepaymentsapi/infrastructure/ConfigValidatorAppListener.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasepaymentsapi/infrastructure/ConfigValidatorAppListener.java
@@ -4,9 +4,11 @@ import com.microsoft.applicationinsights.boot.dependencies.apachecommons.lang3.S
 import lombok.Getter;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.ApplicationListener;
 import org.springframework.context.event.ContextRefreshedEvent;
+import org.springframework.core.env.Environment;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -14,6 +16,11 @@ import org.springframework.stereotype.Component;
 @Getter
 @Setter
 public class ConfigValidatorAppListener implements ApplicationListener<ContextRefreshedEvent> {
+
+    protected static final String CLUSTER_NAME = "CLUSTER_NAME";
+
+    @Autowired
+    private Environment environment;
 
     @Value("${ia.config.validator.secret}")
     private String iaConfigValidatorSecret;
@@ -24,12 +31,19 @@ public class ConfigValidatorAppListener implements ApplicationListener<ContextRe
     }
 
     void breakOnMissingIaConfigValidatorSecret() {
+        String clusterName = environment.getProperty(CLUSTER_NAME);
+        log.info("{} value: {}", CLUSTER_NAME, clusterName);
+        if (StringUtils.isBlank(clusterName)) {
+            log.warn("{} is null or empty. Skipping this check. This is allowed on a developer's local environment "
+                + "but not on a cluster. If you are in a cluster, this warning is going to be a problem.", CLUSTER_NAME);
+            return;
+        }
+
         if (StringUtils.isBlank(iaConfigValidatorSecret)) {
-            log.info("IA Config Validator Secret Value: {}", iaConfigValidatorSecret);
             throw new IllegalArgumentException("ia.config.validator.secret is null or empty."
                 + " This is not allowed and it will break production. This is a secret value stored in a vault"
                 + " (unless running locally). Check application.yaml for further information.");
-
         }
     }
+
 }

--- a/src/main/java/uk/gov/hmcts/reform/iacasepaymentsapi/infrastructure/ConfigValidatorAppListener.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasepaymentsapi/infrastructure/ConfigValidatorAppListener.java
@@ -1,0 +1,35 @@
+package uk.gov.hmcts.reform.iacasepaymentsapi.infrastructure;
+
+import com.microsoft.applicationinsights.boot.dependencies.apachecommons.lang3.StringUtils;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.ApplicationListener;
+import org.springframework.context.event.ContextRefreshedEvent;
+import org.springframework.stereotype.Component;
+
+@Component
+@Slf4j
+@Getter
+@Setter
+public class ConfigValidatorAppListener implements ApplicationListener<ContextRefreshedEvent> {
+
+    @Value("${ia.config.validator.secret}")
+    private String iaConfigValidatorSecret;
+
+    @Override
+    public void onApplicationEvent(ContextRefreshedEvent event) {
+        breakOnMissingIaConfigValidatorSecret();
+    }
+
+    void breakOnMissingIaConfigValidatorSecret() {
+        if (StringUtils.isBlank(iaConfigValidatorSecret)) {
+            log.info("IA Config Validator Secret Value: {}", iaConfigValidatorSecret);
+            throw new IllegalArgumentException("ia.config.validator.secret is null or empty."
+                + " This is not allowed and it will break production. This is a secret value stored in a vault"
+                + " (unless running locally). Check application.yaml for further information.");
+
+        }
+    }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -128,3 +128,5 @@ auth.provider.service.client.baseUrl: ${S2S_URL:http://127.0.0.1:4502}
 idam.s2s-auth.totp_secret: ${IA_S2S_SECRET:AAAAAAAAAAAAAAAC}
 idam.s2s-auth.microservice: ${IA_S2S_MICROSERVICE:something}
 idam.s2s-auth.url: ${S2S_URL:http://127.0.0.1:4502}
+
+ia.config.validator.secret: ${IA_CONFIG_VALIDATOR_SECRET:}

--- a/src/main/resources/bootstrap.yaml
+++ b/src/main/resources/bootstrap.yaml
@@ -12,3 +12,4 @@ spring:
         system-username: IA_SYSTEM_USERNAME
         system-password: IA_SYSTEM_PASSWORD
         AppInsightsInstrumentationKey: azure.application-insights.instrumentation-key
+        ia-config-validator-secret: IA_CONFIG_VALIDATOR_SECRET

--- a/src/test/java/uk/gov/hmcts/reform/iacasepaymentsapi/infrastructure/ConfigValidatorAppListenerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacasepaymentsapi/infrastructure/ConfigValidatorAppListenerTest.java
@@ -1,0 +1,46 @@
+package uk.gov.hmcts.reform.iacasepaymentsapi.infrastructure;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@ExtendWith(MockitoExtension.class)
+class ConfigValidatorAppListenerTest {
+
+    @Test
+    void throwsExceptionWhenIaConfigValidatorSecretIsNull() {
+        // Given
+        ConfigValidatorAppListener configValidatorAppListener = new ConfigValidatorAppListener();
+        configValidatorAppListener.setIaConfigValidatorSecret(null);
+
+        // When/Then
+        assertThrows(IllegalArgumentException.class, configValidatorAppListener::breakOnMissingIaConfigValidatorSecret);
+    }
+
+    @Test
+    void throwsExceptionWhenIaConfigValidatorSecretIsEmpty() {
+        // Given
+        ConfigValidatorAppListener configValidatorAppListener = new ConfigValidatorAppListener();
+        configValidatorAppListener.setIaConfigValidatorSecret("");
+
+        // When/Then
+        assertThrows(IllegalArgumentException.class, configValidatorAppListener::breakOnMissingIaConfigValidatorSecret);
+    }
+
+    @Test
+    @SuppressWarnings("java:S2699") // suppressing SonarLint warning on assertions as it's ok for this test not to have any
+    void runsSuccessfullyWhenIaConfigValidatorSecretsAreCorrectlySet() {
+        // Given
+        ConfigValidatorAppListener configValidatorAppListener = new ConfigValidatorAppListener();
+        configValidatorAppListener.setIaConfigValidatorSecret("secret");
+
+        // When
+        configValidatorAppListener.breakOnMissingIaConfigValidatorSecret();
+
+        // Then
+        // I run successfully till the end
+    }
+
+}

--- a/src/test/java/uk/gov/hmcts/reform/iacasepaymentsapi/infrastructure/ConfigValidatorAppListenerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacasepaymentsapi/infrastructure/ConfigValidatorAppListenerTest.java
@@ -1,45 +1,108 @@
 package uk.gov.hmcts.reform.iacasepaymentsapi.infrastructure;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.core.env.Environment;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static uk.gov.hmcts.reform.iacasepaymentsapi.infrastructure.ConfigValidatorAppListener.CLUSTER_NAME;
 
 @ExtendWith(MockitoExtension.class)
 class ConfigValidatorAppListenerTest {
 
+    @Mock
+    private Environment env;
+
+    private ConfigValidatorAppListener configValidatorAppListener;
+
+    @BeforeEach
+    public void setup() {
+        configValidatorAppListener = new ConfigValidatorAppListener();
+        configValidatorAppListener.setEnvironment(env);
+    }
+
     @Test
-    void throwsExceptionWhenIaConfigValidatorSecretIsNull() {
+    @SuppressWarnings("java:S2699")
+    void throwsExceptionWhenIaConfigValidatorSecretIsNullSimulateLocal() {
         // Given
-        ConfigValidatorAppListener configValidatorAppListener = new ConfigValidatorAppListener();
         configValidatorAppListener.setIaConfigValidatorSecret(null);
-
-        // When/Then
-        assertThrows(IllegalArgumentException.class, configValidatorAppListener::breakOnMissingIaConfigValidatorSecret);
-    }
-
-    @Test
-    void throwsExceptionWhenIaConfigValidatorSecretIsEmpty() {
-        // Given
-        ConfigValidatorAppListener configValidatorAppListener = new ConfigValidatorAppListener();
-        configValidatorAppListener.setIaConfigValidatorSecret("");
-
-        // When/Then
-        assertThrows(IllegalArgumentException.class, configValidatorAppListener::breakOnMissingIaConfigValidatorSecret);
-    }
-
-    @Test
-    @SuppressWarnings("java:S2699") // suppressing SonarLint warning on assertions as it's ok for this test not to have any
-    void runsSuccessfullyWhenIaConfigValidatorSecretsAreCorrectlySet() {
-        // Given
-        ConfigValidatorAppListener configValidatorAppListener = new ConfigValidatorAppListener();
-        configValidatorAppListener.setIaConfigValidatorSecret("secret");
+        when(env.getProperty(CLUSTER_NAME)).thenReturn(null);
 
         // When
         configValidatorAppListener.breakOnMissingIaConfigValidatorSecret();
 
         // Then
+        verify(env).getProperty(CLUSTER_NAME);
+    }
+
+    @Test
+    void throwsExceptionWhenIaConfigValidatorSecretIsNullSimulateCluster() {
+        // Given
+        configValidatorAppListener.setIaConfigValidatorSecret(null);
+        when(env.getProperty(CLUSTER_NAME)).thenReturn("cft-preview-01-aks");
+
+        // When/Then
+        assertThrows(IllegalArgumentException.class, configValidatorAppListener::breakOnMissingIaConfigValidatorSecret);
+        verify(env).getProperty(CLUSTER_NAME);
+    }
+
+    @Test
+    void throwsExceptionWhenIaConfigValidatorSecretIsEmptySimulateLocal() {
+        // Given
+        configValidatorAppListener.setIaConfigValidatorSecret("");
+        when(env.getProperty(CLUSTER_NAME)).thenReturn(null);
+
+        // When
+        configValidatorAppListener.breakOnMissingIaConfigValidatorSecret();
+
+        // Then
+        verify(env).getProperty(CLUSTER_NAME);
+    }
+
+    @Test
+    void throwsExceptionWhenIaConfigValidatorSecretIsEmptySimulateCluster() {
+        // Given
+        configValidatorAppListener.setIaConfigValidatorSecret("");
+        when(env.getProperty(CLUSTER_NAME)).thenReturn("cft-preview-01-aks");
+
+
+        // When/Then
+        assertThrows(IllegalArgumentException.class, configValidatorAppListener::breakOnMissingIaConfigValidatorSecret);
+        verify(env).getProperty(CLUSTER_NAME);
+    }
+
+    @Test
+    @SuppressWarnings("java:S2699") // suppressing SonarLint warning on assertions as it's ok for this test not to have any
+    void runsSuccessfullyWhenIaConfigValidatorSecretsAreCorrectlySetSimulateLocal() {
+        // Given
+        configValidatorAppListener.setIaConfigValidatorSecret("secret");
+        when(env.getProperty(CLUSTER_NAME)).thenReturn(null);
+
+        // When
+        configValidatorAppListener.breakOnMissingIaConfigValidatorSecret();
+
+        // Then
+        verify(env).getProperty(CLUSTER_NAME);
+        // I run successfully till the end
+    }
+
+    @Test
+    @SuppressWarnings("java:S2699") // suppressing SonarLint warning on assertions as it's ok for this test not to have any
+    void runsSuccessfullyWhenIaConfigValidatorSecretsAreCorrectlySetSimulateCluster() {
+        // Given
+        configValidatorAppListener.setIaConfigValidatorSecret("secret");
+        when(env.getProperty(CLUSTER_NAME)).thenReturn("cft-preview-01-aks");
+
+        // When
+        configValidatorAppListener.breakOnMissingIaConfigValidatorSecret();
+
+        // Then
+        verify(env).getProperty(CLUSTER_NAME);
         // I run successfully till the end
     }
 


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RIA-7383


### Change description ###
Adding ia.config.validator.secret to application.yaml + ConfigValidatorAppListener to check to see if secrets are being applied by azure.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
